### PR TITLE
[fix] spelling mistake

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ cargo new --bin my_shell # pick your own name here
 ```toml
 # cargo.toml
 [dependencies]
-libps1 = { git = "https::/github.com/joshmcguigan/libps1" }
+libps1 = { git = "https://github.com/joshmcguigan/libps1" }
 ```
 
 ```rust


### PR DESCRIPTION
The dependency URL was incorrect.