### PR TITLE
Allow configuring prompt char separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ fn main() {
         git_status_clean_icon: "➖",
         git_status_unstaged_icon: "❌",
         git_status_staged_icon: "➕",
+
+        prompt_char_separator: "\n",
         // If you'd prefer not to specify all of the values, uncomment
         // the line below to fall back on a theme. And add the import
         // to the top of the file.

--- a/examples/custom_theme.rs
+++ b/examples/custom_theme.rs
@@ -19,6 +19,8 @@ fn main() {
         git_status_clean_icon: "➖",
         git_status_unstaged_icon: "❌",
         git_status_staged_icon: "➕",
+
+        prompt_char_separator: "\n",
         // If you'd prefer not to specify all of the values, uncomment
         // the line below to fall back on a theme. And add the import
         // to the top of the file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,12 @@ pub struct Prompt {
     pub git_status_clean_icon: &'static str,
     pub git_status_unstaged_icon: &'static str,
     pub git_status_staged_icon: &'static str,
+
+    /// Specify the string used to separate the prompt character
+    /// from the preceding text. Some useful values for this are
+    /// " " (single whitespace) or "\n" to draw the prompt character
+    /// on a new line.
+    pub prompt_char_separator: &'static str,
 }
 
 impl Default for Prompt {
@@ -47,6 +53,8 @@ impl Default for Prompt {
             git_status_clean_icon: "✓",
             git_status_unstaged_icon: "×",
             git_status_staged_icon: "±",
+
+            prompt_char_separator: "\n",
         }
     }
 }
@@ -85,7 +93,7 @@ impl Prompt {
         let cwd = {
             let cwd = self.cwd().unwrap_or_else(|| "".into());
 
-            self.cwd_color.paint(cwd)
+            apply_color(cwd, self.cwd_color)
         };
 
         let vcs_status = vcs_status();
@@ -108,14 +116,20 @@ impl Prompt {
                     }
                 };
                 println!(
-                    "{cwd} {branch} {status}\n{pchar} ",
+                    "{cwd} {branch} {status}{separator}{pchar} ",
                     cwd = cwd,
                     branch = branch,
                     status = status,
+                    separator = self.prompt_char_separator,
                     pchar = prompt_char,
                 )
             }
-            None => println!("{cwd}\n{pchar} ", cwd = cwd, pchar = prompt_char,),
+            None => println!(
+                "{cwd}{separator}{pchar} ",
+                cwd = cwd,
+                separator = self.prompt_char_separator,
+                pchar = prompt_char,
+            ),
         };
     }
 


### PR DESCRIPTION
Closes #2 and #3 

Introduces a new configuration option, `prompt_char_separator`, to allow configuring the prompt character to be on the same line as the preceding text (as opposed to the default two line configuration). 

Doing this required fixing the ansi color code handling. 

In the future, I'd like to allow customizing the color of the prompt, or perhaps setting the color automatically based on the status code of the previous command. I did not do this because by default I think I'd like this to be the standard text color in the terminal (i.e. uncolored). An option here would be to allow this color to be `Option<Color>`, but that would be different than the other color configurations. I'm also not sure what API would make sense for allowing a user to specify either a color, default color, or color based on previous status code. Perhaps a custom enum is necessary here. In any event, this is out of scope for this PR. 

cc @joshtriplett 